### PR TITLE
Update dependencies and fix a bug.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,31 +1,33 @@
-var esprima = require('esprima-fb');
 var recast = require('recast');
+var types = recast.types;
 var through = require('through');
 var b = recast.types.builders;
 var n = recast.types.namedTypes;
 
-var ES6ObjectShort = recast.Visitor.extend({
-  visitProperty: function(expr) {
-    if (expr.shorthand) {
-      expr.shorthand = false;
+function Visitor() {
+  types.PathVisitor.call(this);
+}
+Visitor.prototype = Object.create(types.PathVisitor.prototype);
+Visitor.prototype.constructor = Visitor;
+
+Visitor.prototype.visitProperty = function(prop) {
+  if (n.ObjectExpression.check(prop.parent.node)) {
+    if (prop.node.shorthand) {
+      prop.node.shorthand = false;
     }
-
-    this.genericVisit(expr);
-
-    return expr;
   }
-});
+
+  this.traverse(prop);
+};
 
 function transform(ast) {
-  (new ES6ObjectShort()).visit(ast);
-  return ast;
+  return types.visit(ast, new Visitor());
 }
 
 function compile(code, options) {
   options = options || {};
 
   var recastOptions = {
-    esprima: esprima,
     sourceFileName: options.sourceFileName,
     sourceMapName: options.sourceMapName
   };

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "esprima-fb": "^6001.1001.0-dev-harmony-fb",
-    "recast": "^0.7",
+    "recast": "^0.8",
     "through": "^2.3"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -27,4 +27,8 @@ describe('ES6ObjectShort', function() {
 
     expectTransform(code, result);
   });
+
+  it('should not alter destructuring assignment object patterns', function() {
+    expectTransform('var {a} = 1;', 'var {a} = 1;');
+  });
 });


### PR DESCRIPTION
The fix is that shorthand objects in deconstructing assignment should not be expanded.
