### PR TITLE
visitors should be shared

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,27 +1,12 @@
 var recast = require('recast');
 var types = recast.types;
-var through = require('through');
 var b = recast.types.builders;
 var n = recast.types.namedTypes;
-
-function Visitor() {
-  types.PathVisitor.call(this);
-}
-Visitor.prototype = Object.create(types.PathVisitor.prototype);
-Visitor.prototype.constructor = Visitor;
-
-Visitor.prototype.visitProperty = function(prop) {
-  if (n.ObjectExpression.check(prop.parent.node)) {
-    if (prop.node.shorthand) {
-      prop.node.shorthand = false;
-    }
-  }
-
-  this.traverse(prop);
-};
+var through = require('through');
+var Visitor = require('./visitor');
 
 function transform(ast) {
-  return types.visit(ast, new Visitor());
+  return types.visit(ast, Visitor.visit);
 }
 
 function compile(code, options) {

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -1,0 +1,25 @@
+var recast = require('recast');
+var types = recast.types;
+var b = recast.types.builders;
+var n = recast.types.namedTypes;
+
+function Visitor() {
+  types.PathVisitor.call(this);
+}
+Visitor.prototype = Object.create(types.PathVisitor.prototype);
+Visitor.prototype.constructor = Visitor;
+
+Visitor.prototype.visitProperty = function(prop) {
+  if (n.ObjectExpression.check(prop.parent.node)) {
+    if (prop.node.shorthand) {
+      prop.node.shorthand = false;
+    }
+  }
+
+  this.traverse(prop);
+};
+
+Visitor.visit = new Visitor();
+
+module.exports = Visitor;
+


### PR DESCRIPTION
- extract visitor
- share visitor

before

``` js
node benchmarks/esnext-transform es6-object-short test-input/* 
running...
  - test-input/controller-es5.js x 380 ops/sec ±8.42% (69 runs sampled)
  - test-input/controller.js x 385 ops/sec ±5.09% (75 runs sampled)
  - test-input/empty.js x 7,467 ops/sec ±8.25% (71 runs sampled)
  - test-input/jquery-1.11.1.js x 2.52 ops/sec ±11.96% (11 runs sampled)
  - test-input/simple-export-default-class.js x 3,766 ops/sec ±3.83% (82 runs sampled)
```

after

``` js
node benchmarks/esnext-transform es6-object-short test-input/* 
running...
  - test-input/controller-es5.js x 374 ops/sec ±16.83% (66 runs sampled)
  - test-input/controller.js x 422 ops/sec ±9.49% (75 runs sampled)
  - test-input/empty.js x 78,459 ops/sec ±8.27% (83 runs sampled)
  - test-input/jquery-1.11.1.js x 3.04 ops/sec ±7.17% (11 runs sampled)
  - test-input/simple-export-default-class.js x 6,461 ops/sec ±3.38% (85 runs sampled)
```
